### PR TITLE
Place custom blocks after last `plugins` section

### DIFF
--- a/src/main/kotlin/com/github/h0tk3y/kotlinVersionChanger/DependencyVersionFinder.kt
+++ b/src/main/kotlin/com/github/h0tk3y/kotlinVersionChanger/DependencyVersionFinder.kt
@@ -90,8 +90,6 @@ class DependencyVersionFinder(val groupId: String) : CodeVisitorSupport() {
                     }
                 }
             }
-
-            --depth
         }
 
         if (insidePluginsDsl) {
@@ -125,5 +123,7 @@ class DependencyVersionFinder(val groupId: String) : CodeVisitorSupport() {
             }
             else -> super.visitMethodCallExpression(call)
         }
+
+        --depth
     }
 }

--- a/src/main/kotlin/com/github/h0tk3y/kotlinVersionChanger/Main.kt
+++ b/src/main/kotlin/com/github/h0tk3y/kotlinVersionChanger/Main.kt
@@ -25,7 +25,7 @@ class CliArguments(parser: ArgParser) : VersionChangerArguments {
     override val freeCompilerArgs by parser.storing<List<String>>(
             "--freeCompilerArgs",
             help = "a list of additional compiler arguments that will be passed to the compiler",
-            transform = { this.split(' ') })
+            transform = { if (this.isBlank()) emptyList() else this.split(' ') })
             .default(emptyList())
 }
 


### PR DESCRIPTION
 See https://docs.gradle.org/4.4.1/userguide/plugins.html#sec:plugins_block

The problem is reproduced with the corda project